### PR TITLE
chore: update repo links from fruch to scylladb org

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,6 +1,6 @@
 {
   "projectName": "coodie",
-  "projectOwner": "fruch",
+  "projectOwner": "scylladb",
   "repoType": "github",
   "repoHost": "https://github.com",
   "files": [

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: ["fruch"]
+github: ["scylladb"]

--- a/.github/workflows/self-healing-ci.yml
+++ b/.github/workflows/self-healing-ci.yml
@@ -13,8 +13,8 @@ name: Self-Healing CI
 #
 # Create a fine-grained Personal Access Token with the following settings:
 #   URL:          https://github.com/settings/personal-access-tokens/new
-#   Resource owner: fruch (or the org that owns this repo)
-#   Repository access: Only select repositories → fruch/coodie
+#   Resource owner: scylladb (or the org that owns this repo)
+#   Repository access: Only select repositories → scylladb/coodie
 #   Repository permissions:
 #     • Pull requests: Read and write   ← needed to post PR comments
 #
@@ -24,7 +24,7 @@ name: Self-Healing CI
 # PATs and avoids this limitation.
 #
 # Store the generated token as a repository secret named GH_PAT:
-#   https://github.com/fruch/coodie/settings/secrets/actions/new
+#   https://github.com/scylladb/coodie/settings/secrets/actions/new
 
 on:
   workflow_call:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,15 +259,15 @@ cat > /tmp/rebase-event.json << 'EOF'
   "action": "created",
   "issue": {
     "number": PR_NUMBER,
-    "pull_request": {"url": "https://api.github.com/repos/fruch/coodie/pulls/PR_NUMBER"}
+    "pull_request": {"url": "https://api.github.com/repos/scylladb/coodie/pulls/PR_NUMBER"}
   },
   "comment": {
     "id": COMMENT_ID,
     "body": "/rebase",
     "user": {"login": "fruch", "id": 340979}
   },
-  "repository": {"full_name": "fruch/coodie", "name": "coodie",
-                  "owner": {"login": "fruch"}}
+  "repository": {"full_name": "scylladb/coodie", "name": "coodie",
+                  "owner": {"login": "scylladb"}}
 }
 EOF
 
@@ -339,15 +339,15 @@ using `GITHUB_TOKEN`, but Copilot will not respond to the mention.
 **Creating the PAT:**
 
 1. Go to <https://github.com/settings/personal-access-tokens/new>
-2. Set **Resource owner** to `fruch` (or the org that owns this repo)
-3. Set **Repository access** to **Only select repositories** → `fruch/coodie`
+2. Set **Resource owner** to `scylladb` (or the org that owns this repo)
+3. Set **Repository access** to **Only select repositories** → `scylladb/coodie`
 4. Under **Repository permissions**, grant:
    - **Pull requests: Read and write** — needed to post PR comments
 5. Click **Generate token** and copy the value
 
 **Storing the secret:**
 
-1. Go to <https://github.com/fruch/coodie/settings/secrets/actions/new>
+1. Go to <https://github.com/scylladb/coodie/settings/secrets/actions/new>
 2. Name: `GH_PAT`
 3. Value: paste the token from the previous step
 4. Click **Add secret**
@@ -379,7 +379,7 @@ Publishing to PyPI is triggered automatically whenever a tag matching `v<major>.
 
    | Field | Value |
    |---|---|
-   | Owner | `fruch` |
+   | Owner | `scylladb` |
    | Repository name | `coodie` |
    | Workflow name | `publish.yml` |
    | Environment name | `release` |
@@ -393,4 +393,4 @@ Publishing to PyPI is triggered automatically whenever a tag matching `v<major>.
 
 Once this is done, pushing a version tag such as `v1.0.0` will trigger the workflow and PyPI will accept the upload without any stored credentials.
 
-[gh-issues]: https://github.com/fruch/coodie/issues
+[gh-issues]: https://github.com/scylladb/coodie/issues

--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@
 
 *Cassandra + Beanie (hoodie) = **coodie** 🧥*
 
-[![CI Status](https://img.shields.io/github/actions/workflow/status/fruch/coodie/ci.yml?branch=main&label=CI&logo=github&style=for-the-badge)](https://github.com/fruch/coodie/actions/workflows/ci.yml)
-[![Docs](https://img.shields.io/github/actions/workflow/status/fruch/coodie/docs.yml?branch=main&label=Docs&logo=github&style=for-the-badge)](https://fruch.github.io/coodie/)
-[![Coverage](https://img.shields.io/codecov/c/github/fruch/coodie.svg?logo=codecov&logoColor=fff&style=for-the-badge)](https://codecov.io/gh/fruch/coodie)
+[![CI Status](https://img.shields.io/github/actions/workflow/status/scylladb/coodie/ci.yml?branch=main&label=CI&logo=github&style=for-the-badge)](https://github.com/scylladb/coodie/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/github/actions/workflow/status/scylladb/coodie/docs.yml?branch=main&label=Docs&logo=github&style=for-the-badge)](https://scylladb.github.io/coodie/)
+[![Coverage](https://img.shields.io/codecov/c/github/scylladb/coodie.svg?logo=codecov&logoColor=fff&style=for-the-badge)](https://codecov.io/gh/scylladb/coodie)
 [![PyPI](https://img.shields.io/pypi/v/coodie.svg?logo=python&logoColor=fff&style=for-the-badge)](https://pypi.org/project/coodie/)
 [![Python](https://img.shields.io/pypi/pyversions/coodie.svg?style=for-the-badge&logo=python&logoColor=fff)](https://pypi.org/project/coodie/)
-[![License](https://img.shields.io/pypi/l/coodie.svg?style=for-the-badge)](https://github.com/fruch/coodie/blob/main/LICENSE)
+[![License](https://img.shields.io/pypi/l/coodie.svg?style=for-the-badge)](https://github.com/scylladb/coodie/blob/main/LICENSE)
 
 <p>
-<a href="https://fruch.github.io/coodie/">📖 Documentation</a> •
+<a href="https://scylladb.github.io/coodie/">📖 Documentation</a> •
 <a href="#-quick-start">🚀 Quick Start</a> •
-<a href="https://github.com/fruch/coodie/blob/main/CONTRIBUTING.md">🤝 Contributing</a> •
-<a href="https://github.com/fruch/coodie/blob/main/CHANGELOG.md">📋 Changelog</a>
+<a href="https://github.com/scylladb/coodie/blob/main/CONTRIBUTING.md">🤝 Contributing</a> •
+<a href="https://github.com/scylladb/coodie/blob/main/CHANGELOG.md">📋 Changelog</a>
 </p>
 
 </div>
@@ -262,13 +262,13 @@ await Product.find(brand="Discontinued").allow_filtering().delete()
 
 | Resource | Link |
 |---|---|
-| 📖 **Full Documentation** | [fruch.github.io/coodie](https://fruch.github.io/coodie/) |
-| 🚀 **Quick Start Guide** | [Installation & Quickstart](https://fruch.github.io/coodie/quickstart.html) |
-| 📊 **Benchmark History** | [Performance Trends](https://fruch.github.io/coodie/benchmarks/) |
-| 🔄 **Migrating from cqlengine** | [Migration Guide](https://fruch.github.io/coodie/migration/from-cqlengine.html) |
+| 📖 **Full Documentation** | [scylladb.github.io/coodie](https://scylladb.github.io/coodie/) |
+| 🚀 **Quick Start Guide** | [Installation & Quickstart](https://scylladb.github.io/coodie/quickstart.html) |
+| 📊 **Benchmark History** | [Performance Trends](https://scylladb.github.io/coodie/benchmarks/) |
+| 🔄 **Migrating from cqlengine** | [Migration Guide](https://scylladb.github.io/coodie/migration/from-cqlengine.html) |
 | 🤝 **Contributing** | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | 📋 **Changelog** | [CHANGELOG.md](CHANGELOG.md) |
-| 🐛 **Bug Reports** | [GitHub Issues](https://github.com/fruch/coodie/issues) |
+| 🐛 **Bug Reports** | [GitHub Issues](https://github.com/scylladb/coodie/issues) |
 
 ## Contributors ✨
 
@@ -280,7 +280,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="http://fruch.github.io/"><img src="https://avatars.githubusercontent.com/u/340979?v=4?s=80" width="80px;" alt=""/><br /><sub><b>Israel Fruchter</b></sub></a><br /><a href="https://github.com/fruch/coodie/commits?author=fruch" title="Code">💻</a> <a href="#ideas-fruch" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/fruch/coodie/commits?author=fruch" title="Documentation">📖</a></td>
+    <td align="center"><a href="http://fruch.github.io/"><img src="https://avatars.githubusercontent.com/u/340979?v=4?s=80" width="80px;" alt=""/><br /><sub><b>Israel Fruchter</b></sub></a><br /><a href="https://github.com/scylladb/coodie/commits?author=fruch" title="Code">💻</a> <a href="#ideas-fruch" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/scylladb/coodie/commits?author=fruch" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/docs/plans/cqlengine-feature-parity.md
+++ b/docs/plans/cqlengine-feature-parity.md
@@ -988,5 +988,5 @@ Use this checklist when converting a cqlengine application to coodie:
 ### coodie Documentation
 
 - [coodie rewrite plan](../plan/rewrite-coodie-plan.md) — Original architecture and design decisions
-- [Integration test coverage](https://github.com/fruch/coodie/blob/341a470b35bf60696e2c067d6a22aaf448461102/docs/plans/integration-test-coverage.md) — Current test coverage and gaps
+- [Integration test coverage](https://github.com/scylladb/coodie/blob/341a470b35bf60696e2c067d6a22aaf448461102/docs/plans/integration-test-coverage.md) — Current test coverage and gaps
 - Source code: `src/coodie/` — current implementation

--- a/docs/plans/performance-improvement.md
+++ b/docs/plans/performance-improvement.md
@@ -1,6 +1,6 @@
 # Performance Improvement Plan for coodie
 
-> **Based on**: Benchmark CI run [#22353872673](https://github.com/fruch/coodie/actions/runs/22353872673) — scylla driver ([job](https://github.com/fruch/coodie/actions/runs/22353872673/job/64694559794?pr=31#step:5:122)) and acsylla driver ([job](https://github.com/fruch/coodie/actions/runs/22353872673/job/64694559911?pr=31#step:5:122))
+> **Based on**: Benchmark CI run [#22353872673](https://github.com/scylladb/coodie/actions/runs/22353872673) — scylla driver ([job](https://github.com/scylladb/coodie/actions/runs/22353872673/job/64694559794?pr=31#step:5:122)) and acsylla driver ([job](https://github.com/scylladb/coodie/actions/runs/22353872673/job/64694559911?pr=31#step:5:122))
 > **Date**: 2026-02-24
 > **Status**: Updated with latest benchmark results and cross-driver comparison
 
@@ -549,7 +549,7 @@ self._doc_cls.model_validate(coerce_row_none_collections(self._doc_cls, row))
 
 ## 9. Driver Comparison: scylla-driver vs acsylla
 
-> **Run**: [#22353872673](https://github.com/fruch/coodie/actions/runs/22353872673) — same ScyllaDB container, same benchmark code, different coodie driver.
+> **Run**: [#22353872673](https://github.com/scylladb/coodie/actions/runs/22353872673) — same ScyllaDB container, same benchmark code, different coodie driver.
 > cqlengine always uses scylla-driver regardless of the `--driver-type` option.
 
 ### 9.1 coodie performance by driver (Mean times)
@@ -643,8 +643,8 @@ self._doc_cls.model_validate(coerce_row_none_collections(self._doc_cls, row))
 
 ## 10. Phase 1 Results
 
-> **Post-optimization run**: [#22371151749](https://github.com/fruch/coodie/actions/runs/22371151749) — scylla driver ([job](https://github.com/fruch/coodie/actions/runs/22371151749/job/64752712030?pr=46#step:5:124))
-> **PR**: [#46](https://github.com/fruch/coodie/pull/46) — `perf: implement Phase 1 performance improvements`
+> **Post-optimization run**: [#22371151749](https://github.com/scylladb/coodie/actions/runs/22371151749) — scylla driver ([job](https://github.com/scylladb/coodie/actions/runs/22371151749/job/64752712030?pr=46#step:5:124))
+> **PR**: [#46](https://github.com/scylladb/coodie/pull/46) — `perf: implement Phase 1 performance improvements`
 
 ### 10.1 Phase 1 Changes Implemented
 
@@ -766,8 +766,8 @@ Phase 2's table metadata cache, which is a separate feature (not a code optimiza
 
 ## 11. Phase 2 Results
 
-> **Post-optimization run**: [#22374004611](https://github.com/fruch/coodie/actions/runs/22374004611) — scylla driver ([job](https://github.com/fruch/coodie/actions/runs/22374004611/job/64760385946?pr=57#step:5:124))
-> **PR**: [#57](https://github.com/fruch/coodie/pull/57) — `perf(drivers): implement Phase 2 sync_table optimizations`
+> **Post-optimization run**: [#22374004611](https://github.com/scylladb/coodie/actions/runs/22374004611) — scylla driver ([job](https://github.com/scylladb/coodie/actions/runs/22374004611/job/64760385946?pr=57#step:5:124))
+> **PR**: [#57](https://github.com/scylladb/coodie/pull/57) — `perf(drivers): implement Phase 2 sync_table optimizations`
 
 ### 11.1 Phase 2 Changes Implemented
 
@@ -883,8 +883,8 @@ Phase 2's table metadata cache, which is a separate feature (not a code optimiza
 
 ## 12. Phase 3 Results
 
-> **Post-optimization run**: [#22404800091](https://github.com/fruch/coodie/actions/runs/22404800091) — scylla driver ([job](https://github.com/fruch/coodie/actions/runs/22404800091/job/64861387772?pr=61#step:5:124))
-> **PR**: [#61](https://github.com/fruch/coodie/pull/61) — `perf: implement Phase 3 query path optimizations (tasks 3.6, 3.7, 3.8)`
+> **Post-optimization run**: [#22404800091](https://github.com/scylladb/coodie/actions/runs/22404800091) — scylla driver ([job](https://github.com/scylladb/coodie/actions/runs/22404800091/job/64861387772?pr=61#step:5:124))
+> **PR**: [#61](https://github.com/scylladb/coodie/pull/61) — `perf: implement Phase 3 query path optimizations (tasks 3.6, 3.7, 3.8)`
 
 ### 12.1 Phase 3 Changes Implemented
 
@@ -1215,8 +1215,8 @@ limitations.
 
 ### 13B.3 Phase 5 Results
 
-> **Post-optimization run**: [#22417171511](https://github.com/fruch/coodie/actions/runs/22417171511) — scylla driver ([job](https://github.com/fruch/coodie/actions/runs/22417171511/job/64905668613))
-> **PR**: [#78](https://github.com/fruch/coodie/pull/78) — `perf: Phase 5 — PK column cache and native async for CassandraDriver`
+> **Post-optimization run**: [#22417171511](https://github.com/scylladb/coodie/actions/runs/22417171511) — scylla driver ([job](https://github.com/scylladb/coodie/actions/runs/22417171511/job/64905668613))
+> **PR**: [#78](https://github.com/scylladb/coodie/pull/78) — `perf: Phase 5 — PK column cache and native async for CassandraDriver`
 
 #### 13B.3.1 Core Operations — Phase 3 vs Phase 5
 
@@ -1318,8 +1318,8 @@ limitations.
 
 ## 13C. Phase 6 — Custom `dict_factory` for CassandraDriver
 
-> **PR**: [#113](https://github.com/fruch/coodie/pull/113) — `perf(drivers): set dict_factory on CassandraDriver session for zero-copy rows`
-> **Pre-change baseline run**: [#22488403820](https://github.com/fruch/coodie/actions/runs/22488403820) — scylla driver ([job](https://github.com/fruch/coodie/actions/runs/22488403820/job/65143784056)) — commit `8db913f` on master, 2026-02-27
+> **PR**: [#113](https://github.com/scylladb/coodie/pull/113) — `perf(drivers): set dict_factory on CassandraDriver session for zero-copy rows`
+> **Pre-change baseline run**: [#22488403820](https://github.com/scylladb/coodie/actions/runs/22488403820) — scylla driver ([job](https://github.com/scylladb/coodie/actions/runs/22488403820/job/65143784056)) — commit `8db913f` on master, 2026-02-27
 
 ### 13C.1 Change Implemented
 
@@ -1351,7 +1351,7 @@ CassandraDriver.execute()
 **Savings per query**: Eliminates `_asdict()` (returns OrderedDict) + `dict()` wrapping for each row.
 For a 1-row query (GET by PK): ~30–50 µs. For a 10-row query: ~300–500 µs.
 
-### 13C.2 Pre-Change Baseline (run [#22488403820](https://github.com/fruch/coodie/actions/runs/22488403820))
+### 13C.2 Pre-Change Baseline (run [#22488403820](https://github.com/scylladb/coodie/actions/runs/22488403820))
 
 The most recent master run before this change confirms Phase 5 numbers are stable:
 
@@ -1417,14 +1417,14 @@ The change makes path 2 the default for all CassandraDriver queries.
 > 🔲 **Pending**: Will be filled in once PR #113 is merged and the benchmark workflow runs on master.
 >
 > The benchmark workflow auto-pushes to `gh-pages` on every `master` push, so results will
-> be visible at `https://fruch.github.io/coodie/benchmarks/scylla/` after merge.
+> be visible at `https://scylladb.github.io/coodie/benchmarks/scylla/` after merge.
 
 ---
 
 ## 13D. Phase 7 — `__slots__` on LWTResult, PagedResult, and BatchQuery
 
-> **PR**: [#120](https://github.com/fruch/coodie/pull/120) — `perf: add __slots__ to LWTResult, PagedResult, and BatchQuery`
-> **Benchmark run**: [#22530373428](https://github.com/fruch/coodie/actions/runs/22530373428) — scylla driver ([job](https://github.com/fruch/coodie/actions/runs/22530373428/job/65268812271)) — commit `065c756` on `copilot/add-slots-to-hot-path-classes`, 2026-02-28
+> **PR**: [#120](https://github.com/scylladb/coodie/pull/120) — `perf: add __slots__ to LWTResult, PagedResult, and BatchQuery`
+> **Benchmark run**: [#22530373428](https://github.com/scylladb/coodie/actions/runs/22530373428) — scylla driver ([job](https://github.com/scylladb/coodie/actions/runs/22530373428/job/65268812271)) — commit `065c756` on `copilot/add-slots-to-hot-path-classes`, 2026-02-28
 
 ### 13D.1 Changes Implemented
 
@@ -1529,7 +1529,7 @@ noise floor of CI benchmarks), consistent with the original §14.5.4 estimate.
 ## 13E. Phase 8 — Benchmark Review & Next-Level Optimizations
 
 > **Date**: 2026-02-28
-> **Based on**: Phase 7 benchmark results (run [#22530373428](https://github.com/fruch/coodie/actions/runs/22530373428))
+> **Based on**: Phase 7 benchmark results (run [#22530373428](https://github.com/scylladb/coodie/actions/runs/22530373428))
 > **Status**: Proposed
 
 ### 13E.1 Current Benchmark Summary
@@ -1809,8 +1809,8 @@ The remaining 3–4 losses would all be in the "accepted Pydantic trade-off" cat
 
 ## 13F. Phase 8b — Connection-Level Optimizations (§14.5.6)
 
-> **PR**: [#137](https://github.com/fruch/coodie/pull/137) — `feat(drivers): connection-level performance optimizations — compression, speculative execution, prepared statement warming`
-> **Baseline**: Phase 7 (13D) benchmark run [#22530373428](https://github.com/fruch/coodie/actions/runs/22530373428) — scylla driver ([job](https://github.com/fruch/coodie/actions/runs/22530373428/job/65268812271)) — commit `065c756`, 2026-02-28
+> **PR**: [#137](https://github.com/scylladb/coodie/pull/137) — `feat(drivers): connection-level performance optimizations — compression, speculative execution, prepared statement warming`
+> **Baseline**: Phase 7 (13D) benchmark run [#22530373428](https://github.com/scylladb/coodie/actions/runs/22530373428) — scylla driver ([job](https://github.com/scylladb/coodie/actions/runs/22530373428/job/65268812271)) — commit `065c756`, 2026-02-28
 
 ### 13F.1 Changes Implemented
 
@@ -1922,7 +1922,7 @@ The §14.5.6 optimizations are **deployment-time configuration improvements** ra
 ## 13G. Phase 9 — Raw+DC Benchmark Analysis & Optimization Targets
 
 > **Date**: 2026-03-05
-> **Based on**: Raw+DC benchmarks added in PR [#187](https://github.com/fruch/coodie/pull/187) — CI run [#22739849451](https://github.com/fruch/coodie/actions/runs/22739849451) — commit `313a210`
+> **Based on**: Raw+DC benchmarks added in PR [#187](https://github.com/scylladb/coodie/pull/187) — CI run [#22739849451](https://github.com/scylladb/coodie/actions/runs/22739849451) — commit `313a210`
 > **Status**: Analysis complete, proposed optimizations pending implementation
 
 ### 13G.1 Background

--- a/docs/plans/pr-comment-rebase-squash-action.md
+++ b/docs/plans/pr-comment-rebase-squash-action.md
@@ -272,7 +272,7 @@ Follow these steps to generate the workflow push token:
    | **Expiration** | Pick a reasonable lifetime (e.g., 90 days); set a calendar reminder to rotate |
    | **Description** | "Push access for branches with .github/workflows/ changes" |
    | **Resource owner** | Your personal account (any collaborator with write access) |
-   | **Repository access** | Select **"Only select repositories"** and choose `fruch/coodie` |
+   | **Repository access** | Select **"Only select repositories"** and choose `scylladb/coodie` |
 
 3. **Set permissions:**
 
@@ -293,7 +293,7 @@ Follow these steps to generate the workflow push token:
 > `https://github.com/OWNER/REPO/settings/secrets/actions/new`
 >
 > For this repository:
-> [`https://github.com/fruch/coodie/settings/secrets/actions/new`](https://github.com/fruch/coodie/settings/secrets/actions/new)
+> [`https://github.com/scylladb/coodie/settings/secrets/actions/new`](https://github.com/scylladb/coodie/settings/secrets/actions/new)
 
 1. Open the link above, or navigate: Repository → **Settings** → **Secrets and
    variables** → **Actions** → **New repository secret**

--- a/docs/plans/raw-dc-benchmark-plan.md
+++ b/docs/plans/raw-dc-benchmark-plan.md
@@ -90,7 +90,7 @@ ScyllaDB testcontainer — the same infrastructure the existing benchmarks use.
 
 ## 5. Benchmark Results
 
-> **CI Run:** [#22739849451](https://github.com/fruch/coodie/actions/runs/22739849451) — commit `313a210` (all 86 benchmarks passed)
+> **CI Run:** [#22739849451](https://github.com/scylladb/coodie/actions/runs/22739849451) — commit `313a210` (all 86 benchmarks passed)
 > **Backend:** ScyllaDB testcontainer · **Driver:** cassandra-driver with `dict_factory`
 
 ### 5.1 Three-Way Comparison — Raw+DC vs coodie vs cqlengine

--- a/docs/source/guide/benchmarks.md
+++ b/docs/source/guide/benchmarks.md
@@ -58,9 +58,9 @@ Results are published to the `gh-pages` branch using
 This provides:
 
 * **Historical trend charts** — viewable on the repository's GitHub Pages site:
-  * [scylla driver benchmarks](https://fruch.github.io/coodie/benchmarks/scylla/)
-  * [acsylla driver benchmarks](https://fruch.github.io/coodie/benchmarks/acsylla/)
-  * [all benchmarks overview](https://fruch.github.io/coodie/benchmarks/)
+  * [scylla driver benchmarks](https://scylladb.github.io/coodie/benchmarks/scylla/)
+  * [acsylla driver benchmarks](https://scylladb.github.io/coodie/benchmarks/acsylla/)
+  * [all benchmarks overview](https://scylladb.github.io/coodie/benchmarks/)
 * **Regression alerts** — when a benchmark regresses beyond 150% of its
   previous value, an alert comment is posted on the commit or pull request.
 * **Workflow summary** — every CI run includes a benchmark summary in the

--- a/docs/source/guide/integrations.md
+++ b/docs/source/guide/integrations.md
@@ -118,7 +118,7 @@ uvicorn app:app --reload
 ### Full Demo
 
 A complete FastAPI + HTMX demo lives in the repository under
-[`demo/`](https://github.com/fruch/coodie/tree/master/demo).
+[`demo/`](https://github.com/scylladb/coodie/tree/master/demo).
 
 ---
 

--- a/docs/source/guide/user-defined-types.md
+++ b/docs/source/guide/user-defined-types.md
@@ -150,7 +150,7 @@ home: Annotated[Address, Frozen()]   # Frozen() is redundant but accepted
 ```{note}
 Non-frozen UDT support (for partial field updates on top-level columns) may
 be added in a future coodie release.  See the
-[UDT support plan](https://github.com/fruch/coodie/blob/main/docs/plans/udt-support.md)
+[UDT support plan](https://github.com/scylladb/coodie/blob/main/docs/plans/udt-support.md)
 for the roadmap.
 ```
 

--- a/docs/source/llms-full.txt
+++ b/docs/source/llms-full.txt
@@ -378,9 +378,9 @@ except DocumentNotFound:
 
 ## Project Links
 
-- [GitHub Repository](https://github.com/fruch/coodie)
+- [GitHub Repository](https://github.com/scylladb/coodie)
 - [PyPI Package](https://pypi.org/project/coodie/)
-- [Full Documentation](https://fruch.github.io/coodie/)
-- [Changelog](https://fruch.github.io/coodie/changelog.html)
-- [Contributing Guide](https://fruch.github.io/coodie/contributing.html)
-- [Migration from cqlengine](https://fruch.github.io/coodie/migration/from-cqlengine.html)
+- [Full Documentation](https://scylladb.github.io/coodie/)
+- [Changelog](https://scylladb.github.io/coodie/changelog.html)
+- [Contributing Guide](https://scylladb.github.io/coodie/contributing.html)
+- [Migration from cqlengine](https://scylladb.github.io/coodie/migration/from-cqlengine.html)

--- a/docs/source/llms.txt
+++ b/docs/source/llms.txt
@@ -4,48 +4,48 @@
 
 ## Docs
 
-- [Installation](https://fruch.github.io/coodie/installation.html): How to install coodie and choose a driver
-- [Quick Start](https://fruch.github.io/coodie/quickstart.html): From zero to first query in 60 seconds
-- [Defining Documents](https://fruch.github.io/coodie/guide/defining-documents.html): Document classes, fields, and Pydantic v2 integration
-- [Field Types](https://fruch.github.io/coodie/guide/field-types.html): All supported field types and type annotations
-- [Keys and Indexes](https://fruch.github.io/coodie/guide/keys-and-indexes.html): Primary keys, clustering keys, and secondary indexes
-- [CRUD Operations](https://fruch.github.io/coodie/guide/crud.html): Create, read, update, delete operations
-- [Querying](https://fruch.github.io/coodie/guide/querying.html): QuerySet API and chaining
-- [Filtering](https://fruch.github.io/coodie/guide/filtering.html): Django-style filter lookups
-- [Collections](https://fruch.github.io/coodie/guide/collections.html): List, set, map, and tuple field operations
-- [Counters](https://fruch.github.io/coodie/guide/counters.html): Counter columns with increment/decrement
-- [TTL](https://fruch.github.io/coodie/guide/ttl.html): Time-To-Live support for automatic row expiration
-- [LWT](https://fruch.github.io/coodie/guide/lwt.html): Lightweight Transactions (compare-and-set)
-- [Batch Operations](https://fruch.github.io/coodie/guide/batch-operations.html): Batch CQL statements
-- [Sync vs Async](https://fruch.github.io/coodie/guide/sync-vs-async.html): Dual-stack API comparison
-- [Drivers](https://fruch.github.io/coodie/guide/drivers.html): CassandraDriver, AcsyllaDriver, and initialization
-- [Exceptions](https://fruch.github.io/coodie/guide/exceptions.html): Error handling reference
-- [Recipes](https://fruch.github.io/coodie/guide/recipes.html): Advanced patterns and recipes
-- [Integrations](https://fruch.github.io/coodie/guide/integrations.html): FastAPI and Flask integration examples
+- [Installation](https://scylladb.github.io/coodie/installation.html): How to install coodie and choose a driver
+- [Quick Start](https://scylladb.github.io/coodie/quickstart.html): From zero to first query in 60 seconds
+- [Defining Documents](https://scylladb.github.io/coodie/guide/defining-documents.html): Document classes, fields, and Pydantic v2 integration
+- [Field Types](https://scylladb.github.io/coodie/guide/field-types.html): All supported field types and type annotations
+- [Keys and Indexes](https://scylladb.github.io/coodie/guide/keys-and-indexes.html): Primary keys, clustering keys, and secondary indexes
+- [CRUD Operations](https://scylladb.github.io/coodie/guide/crud.html): Create, read, update, delete operations
+- [Querying](https://scylladb.github.io/coodie/guide/querying.html): QuerySet API and chaining
+- [Filtering](https://scylladb.github.io/coodie/guide/filtering.html): Django-style filter lookups
+- [Collections](https://scylladb.github.io/coodie/guide/collections.html): List, set, map, and tuple field operations
+- [Counters](https://scylladb.github.io/coodie/guide/counters.html): Counter columns with increment/decrement
+- [TTL](https://scylladb.github.io/coodie/guide/ttl.html): Time-To-Live support for automatic row expiration
+- [LWT](https://scylladb.github.io/coodie/guide/lwt.html): Lightweight Transactions (compare-and-set)
+- [Batch Operations](https://scylladb.github.io/coodie/guide/batch-operations.html): Batch CQL statements
+- [Sync vs Async](https://scylladb.github.io/coodie/guide/sync-vs-async.html): Dual-stack API comparison
+- [Drivers](https://scylladb.github.io/coodie/guide/drivers.html): CassandraDriver, AcsyllaDriver, and initialization
+- [Exceptions](https://scylladb.github.io/coodie/guide/exceptions.html): Error handling reference
+- [Recipes](https://scylladb.github.io/coodie/guide/recipes.html): Advanced patterns and recipes
+- [Integrations](https://scylladb.github.io/coodie/guide/integrations.html): FastAPI and Flask integration examples
 
 ## Migration
 
-- [From cqlengine](https://fruch.github.io/coodie/migration/from-cqlengine.html): Side-by-side migration guide from cqlengine to coodie
-- [Argus Example](https://fruch.github.io/coodie/migration/argus-example.html): Real-world migration case study
+- [From cqlengine](https://scylladb.github.io/coodie/migration/from-cqlengine.html): Side-by-side migration guide from cqlengine to coodie
+- [Argus Example](https://scylladb.github.io/coodie/migration/argus-example.html): Real-world migration case study
 
 ## API Reference
 
-- [Document](https://fruch.github.io/coodie/api/document.html): Document, CounterDocument, and MaterializedView classes
-- [QuerySet](https://fruch.github.io/coodie/api/queryset.html): Chainable query builder API
-- [Fields](https://fruch.github.io/coodie/api/fields.html): PrimaryKey, ClusteringKey, Indexed, Counter, and type markers
-- [Types](https://fruch.github.io/coodie/api/types.html): Python-to-CQL type mapping utilities
-- [Drivers](https://fruch.github.io/coodie/api/drivers.html): Driver registry, AbstractDriver, and CassandraDriver
-- [Exceptions](https://fruch.github.io/coodie/api/exceptions.html): CoodieError hierarchy
-- [Results](https://fruch.github.io/coodie/api/results.html): LWTResult and PagedResult
-- [Batch](https://fruch.github.io/coodie/api/batch.html): BatchQuery and AsyncBatchQuery
+- [Document](https://scylladb.github.io/coodie/api/document.html): Document, CounterDocument, and MaterializedView classes
+- [QuerySet](https://scylladb.github.io/coodie/api/queryset.html): Chainable query builder API
+- [Fields](https://scylladb.github.io/coodie/api/fields.html): PrimaryKey, ClusteringKey, Indexed, Counter, and type markers
+- [Types](https://scylladb.github.io/coodie/api/types.html): Python-to-CQL type mapping utilities
+- [Drivers](https://scylladb.github.io/coodie/api/drivers.html): Driver registry, AbstractDriver, and CassandraDriver
+- [Exceptions](https://scylladb.github.io/coodie/api/exceptions.html): CoodieError hierarchy
+- [Results](https://scylladb.github.io/coodie/api/results.html): LWTResult and PagedResult
+- [Batch](https://scylladb.github.io/coodie/api/batch.html): BatchQuery and AsyncBatchQuery
 
 ## Project
 
-- [GitHub Repository](https://github.com/fruch/coodie)
+- [GitHub Repository](https://github.com/scylladb/coodie)
 - [PyPI Package](https://pypi.org/project/coodie/)
-- [Changelog](https://fruch.github.io/coodie/changelog.html)
-- [Contributing](https://fruch.github.io/coodie/contributing.html)
+- [Changelog](https://scylladb.github.io/coodie/changelog.html)
+- [Contributing](https://scylladb.github.io/coodie/contributing.html)
 
 ## Optional
 
-- [llms-full.txt](https://fruch.github.io/coodie/llms-full.txt): Comprehensive single-file documentation for LLMs
+- [llms-full.txt](https://scylladb.github.io/coodie/llms-full.txt): Comprehensive single-file documentation for LLMs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,11 @@ python-rs = [
 coodie = "coodie.migrations.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/fruch/coodie"
-Documentation = "https://fruch.github.io/coodie/"
-Repository = "https://github.com/fruch/coodie"
-"Bug Tracker" = "https://github.com/fruch/coodie/issues"
-Changelog = "https://github.com/fruch/coodie/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/scylladb/coodie"
+Documentation = "https://scylladb.github.io/coodie/"
+Repository = "https://github.com/scylladb/coodie"
+"Bug Tracker" = "https://github.com/scylladb/coodie/issues"
+Changelog = "https://github.com/scylladb/coodie/blob/main/CHANGELOG.md"
 
 # NOTE: We'd prefer to use uv_build here, but it doesn't yet support dynamic
 # versioning from VCS. Switch back once uv_build gains this support:


### PR DESCRIPTION
## Summary

- Updated all GitHub repo URLs from `fruch/coodie` to `scylladb/coodie` across 15 files
- Updated all GitHub Pages URLs from `fruch.github.io/coodie` to `scylladb.github.io/coodie`
- Updated org-level references (FUNDING.yml, .all-contributorsrc projectOwner, workflow comments, PyPI publisher config)
- Preserved personal identity references (author name/email, contributor login, personal profile URL)

## Test plan

- [x] Verify links in README.md render correctly and point to scylladb org
- [x] Verify `pyproject.toml` URLs are correct
- [x] Verify GitHub Pages documentation links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)