### PR TITLE
fix(ci): grant pull-requests write permission to claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary
- The Claude Code Review action was failing with `401 Unauthorized - User does not have write access on this repository` because `pull-requests` permission was set to `read`
- Changed `pull-requests: read` to `pull-requests: write` so the action can post review comments on PRs

## Test plan
- [ ] Verify the claude-code-review workflow passes on this PR (it will review itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)