### PR TITLE
ci(renovate): show semver versions in GitHub Actions digest PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,32 +3,57 @@
   "extends": [
     "github>browniebroke/renovate-configs:python",
     "schedule:weekly",
-    ":separateMajorReleases"
+    ":separateMajorReleases",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "commitBodyTable": true,
   "minimumReleaseAge": "7 days",
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": ["security"],
-    "schedule": ["at any time"],
+    "labels": [
+      "security"
+    ],
+    "schedule": [
+      "at any time"
+    ],
     "minimumReleaseAge": "0 days"
   },
   "packageRules": [
     {
       "description": "Group all non-major Python dependency updates",
-      "matchManagers": ["pep621", "uv"],
-      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchManagers": [
+        "pep621",
+        "uv"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
       "groupName": "python dependencies (non-major)"
     },
     {
       "description": "Group all GitHub Actions updates",
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
       "groupName": "github-actions (non-major)"
     },
     {
       "description": "Group all pre-commit hook updates",
-      "matchManagers": ["pre-commit"],
-      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchManagers": [
+        "pre-commit"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
       "groupName": "pre-commit hooks (non-major)"
     }
   ]


### PR DESCRIPTION
Add `helpers:pinGitHubActionDigestsToSemver` preset so Renovate extracts
the actual semver tag (e.g. v6.0.2 → v6.0.3) when updating SHA-pinned
GitHub Actions, instead of only showing opaque digest fragments.

Enable `commitBodyTable` to include a version table in commit messages
showing datasource, package, and version change.

This keeps SHA pinning for security while making digest update PRs
informative with proper version context, release notes, and diffs.

Mirrors: https://github.com/scylladb/scylla-cluster-tests/commit/b2b9a495d606d9555532b815706aadd7311d4147